### PR TITLE
fix nested anchor tag error and a typo

### DIFF
--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -98,11 +98,9 @@ export default function SignIn() {
                                 </Typography>
                                 <Typography level="body-sm">
                                     Are you new here?{' '}
-                                    <Link to="/register" >
-                                        <MuiLink level="title-sm">
-                                            Sign in!
-                                        </MuiLink>
-                                    </Link>
+                                    <MuiLink level="title-sm" component={Link} to="/register">
+                                        Sign up!
+                                    </MuiLink>
                                 </Typography>
                             </Stack>
 

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -111,11 +111,9 @@ export default function SignUp() {
                                 </Typography>
                                 <Typography level="body-sm">
                                     Already Have an Account?{' '}
-                                    <Link to="/login" >
-                                        <MuiLink level="title-sm">
-                                            Sign in!
-                                        </MuiLink>
-                                    </Link>
+                                    <MuiLink level="title-sm" component={Link} to="/login">
+                                        Sign in!
+                                    </MuiLink>
                                 </Typography>
                             </Stack>
 


### PR DESCRIPTION
there was an error in the console about nested anchor tags on the login and signup pages and it's been fixed. also a typo.